### PR TITLE
Migrate staging to proposed

### DIFF
--- a/etc/apt/preferences.d/pop-default-settings
+++ b/etc/apt/preferences.d/pop-default-settings
@@ -3,5 +3,5 @@ Pin: release o=LP-PPA-system76-pop
 Pin-Priority: 1001
 
 Package: *
-Pin: release o=LP-PPA-system76-pop-staging
+Pin: release o=LP-PPA-system76-proposed
 Pin-Priority: 1001

--- a/etc/update-manager/release-upgrades.d/pop-default-settings.cfg
+++ b/etc/update-manager/release-upgrades.d/pop-default-settings.cfg
@@ -1,3 +1,3 @@
 [ThirdPartyMirrors]
 system76_pop = http://ppa.launchpad.net/system76/pop/ubuntu/
-system76_pop_staging = http://ppa.launchpad.net/system76/pop-staging/ubuntu/
+system76_proposed = http://ppa.launchpad.net/system76/proposed/ubuntu/


### PR DESCRIPTION
This switches the staging repo to the proposed repo, where we will now be storing packages before release.