### PR TITLE
Use Pop logo for ubuntu-logo-icon. Fixes pop-os/gtk-theme#91 for real

### DIFF
--- a/usr/share/icons/pop-os-branding/round-logos/16/ubuntu-logo-icon.svg
+++ b/usr/share/icons/pop-os-branding/round-logos/16/ubuntu-logo-icon.svg
@@ -1,0 +1,1 @@
+distributor-logo.svg


### PR DESCRIPTION
Really fixes pop-os/gtk-theme#91