### PR TITLE
Add PPA if missing

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -18,5 +18,6 @@ Depends: ${misc:Depends},
          pop-session,
          pop-theme,
          pop-wallpapers,
+         software-properties-common,
 Description: default settings for the Pop desktop
  This package contains the default settings used by Pop.

--- a/debian/control
+++ b/debian/control
@@ -10,9 +10,10 @@ Homepage: https://github.com/system76/pop-default-settings
 Package: pop-default-settings
 Architecture: any
 Depends: ${misc:Depends},
-         base-files,
+         base-files (>= 10),
          libglib2.0-bin,
          gnome-menus,
+         gnupg,
          plymouth-theme-pop-basic,
          pop-session,
          pop-theme,

--- a/debian/pop-default-settings.postinst
+++ b/debian/pop-default-settings.postinst
@@ -21,6 +21,13 @@ case "$1" in
         ;;
 esac
 
+# Add the Pop proprietary PPA if it is missing.
+if ! grep 'apt.pop-os.org/proprietary' /etc/apt/sources.list; then
+    # TODO: perhaps make this key part of a keyring package?
+    apt-key adv --keyserver "hkp://keyserver.ubuntu.com:80" --recv-keys "204DD8AEC33A7AFF"
+    add-apt-repository "deb http://apt.pop-os.org/proprietary $(lsb_release -cs) main"
+fi
+
 #DEBHELPER#
 
 exit 0

--- a/debian/pop-default-settings.postinst
+++ b/debian/pop-default-settings.postinst
@@ -15,18 +15,21 @@ case "$1" in
             dpkg-divert --add --package pop-default-settings --rename --divert "/etc/$f.diverted" "/etc/$f"
             [ \! -e "/etc/$f" -o -L "/etc/$f" ] && ln --force --relative --symbolic "/etc/pop-os/$f" "/etc/$f"
         done
+        
+        # Add Pop proprietary repo if it is missing.
+        RELEASE="$(lsb_release -cs)"
+        REPO="deb http://apt.pop-os.org/proprietary ${RELEASE} main"
+        KEY="204DD8AEC33A7AFF"
+        if ! grep "${REPO}" /etc/apt/sources.list > /dev/null
+        then
+            apt-key adv --keyserver "keyserver.ubuntu.com" --recv-keys "${KEY}"
+            add-apt-repository "${REPO}"
+        fi
         ;;
 
     *)
         ;;
 esac
-
-# Add the Pop proprietary PPA if it is missing.
-if ! grep 'apt.pop-os.org/proprietary' /etc/apt/sources.list; then
-    # TODO: perhaps make this key part of a keyring package?
-    apt-key adv --keyserver "keyserver.ubuntu.com" --recv-keys "204DD8AEC33A7AFF"
-    add-apt-repository "deb http://apt.pop-os.org/proprietary $(lsb_release -cs) main"
-fi
 
 #DEBHELPER#
 

--- a/debian/pop-default-settings.postinst
+++ b/debian/pop-default-settings.postinst
@@ -23,7 +23,7 @@ case "$1" in
         if ! grep "${REPO}" /etc/apt/sources.list > /dev/null
         then
             apt-key adv --keyserver "keyserver.ubuntu.com" --recv-keys "${KEY}"
-            add-apt-repository "${REPO}"
+            add-apt-repository --yes "${REPO}"
         fi
         ;;
 

--- a/debian/pop-default-settings.postinst
+++ b/debian/pop-default-settings.postinst
@@ -24,7 +24,7 @@ esac
 # Add the Pop proprietary PPA if it is missing.
 if ! grep 'apt.pop-os.org/proprietary' /etc/apt/sources.list; then
     # TODO: perhaps make this key part of a keyring package?
-    apt-key adv --keyserver "hkp://keyserver.ubuntu.com:80" --recv-keys "204DD8AEC33A7AFF"
+    apt-key adv --keyserver "keyserver.ubuntu.com" --recv-keys "204DD8AEC33A7AFF"
     add-apt-repository "deb http://apt.pop-os.org/proprietary $(lsb_release -cs) main"
 fi
 


### PR DESCRIPTION
This will add the proprietary PPA to `/etc/apt/sources.list` if it does not already exist in the file.