### PR TITLE
Update seahorse.desktop in disco

### DIFF
--- a/usr/bin/pop-app-folders
+++ b/usr/bin/pop-app-folders
@@ -27,7 +27,7 @@ gsettings set "${APP_FOLDER}-System/" apps "[
 'org.gnome.baobab.desktop',
 'org.gnome.DiskUtility.desktop',
 'org.gnome.PowerStats.desktop',
-'seahorse.desktop',
+'org.gnome.seahorse.Application.desktop',
 'software-properties-gnome.desktop',
 'system76-driver.desktop',
 'system76-firmware.desktop'


### PR DESCRIPTION
In 18.*, seahorse could be found at `/usr/share/applications/seahorse.desktop`. In 19.04, it is `org.gnome.seahorse.Application.desktop`. This pr updates the name in `usr/bin/pop-app-folders` because the seahorse application was not in the appropriate "System" folder.