### PR TITLE
Disable suspend when on battery and the system is inactive

### DIFF
--- a/debian/pop-default-settings.gsettings-override
+++ b/debian/pop-default-settings.gsettings-override
@@ -19,6 +19,7 @@ logo = ''
 
 [org.gnome.settings-daemon.plugins.power]
 sleep-inactive-ac-type = 'nothing'
+sleep-inactive-battery-type = 'nothing'
 
 ##########################
 # initial-setup settings #


### PR DESCRIPTION
pt1/3 for https://github.com/pop-os/default-settings/issues/48