### PR TITLE
Set default calendar app correctly

### DIFF
--- a/usr/share/applications/pop-mimeapps.list
+++ b/usr/share/applications/pop-mimeapps.list
@@ -3,3 +3,4 @@ application/x-debian-package=com.github.donadigo.eddy.desktop
 application/x-cd-image=popsicle.desktop
 application/x-raw-disk-image=popsicle.desktop
 application/x-raw-disk-image-xz-compressed=popsicle.desktop
+text/calendar=org.gnome.Calendar.desktop


### PR DESCRIPTION
Fixes https://github.com/pop-os/gnome-control-center/issues/20