### PR TITLE
Fix sourceview styles

### DIFF
--- a/debian/pop-default-settings.gsettings-override
+++ b/debian/pop-default-settings.gsettings-override
@@ -39,6 +39,12 @@ theme = "Pop"
 titlebar-font = 'Fira Sans Semi-Bold 10'
 titlebar-uses-system-font = false
 
+##################
+# Gedit Settings #
+##################
+[org.gnome.gedit.preferences.editor]
+scheme = 'pop-light'
+
 #####################
 # Terminal settings #
 #####################

--- a/usr/share/gtksourceview-4/styles/pop-dark.xml
+++ b/usr/share/gtksourceview-4/styles/pop-dark.xml
@@ -1,0 +1,118 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+  This file is part of GtkSourceView
+
+  Copyright (C) 2018 Ian Santopietro
+  Author: Ian Santopietro <isantop@gmail.com>
+
+  GtkSourceView is free software; you can redistribute it and/or
+  modify it under the terms of the GNU Lesser General Public
+  License as published by the Free Software Foundation; either
+  version 2.1 of the License, or (at your option) any later version.
+
+  GtkSourceView is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+  Lesser General Public License for more details.
+
+  You should have received a copy of the GNU Lesser General Public
+  License along with this library; if not, write to the Free Software
+  Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+
+-->
+<style-scheme id="pop-dark" _name="Pop Dark" version="1.0">
+  <author>Ian Santopietro</author>
+  <_description>Color scheme using Pop color palette</_description>
+
+  <!-- Pop Palette -->
+  <color name="yellow"       value="#ffce51"/>
+  <color name="orange"       value="#faa41a"/>
+  <color name="red"          value="#f15d22"/>
+  <color name="magenta"      value="#FF3077"/>
+  <color name="violet"       value="#D86EEB"/>
+  <color name="blue"         value="#8D9DF7"/>
+  <color name="cyan"         value="#48b9c7"/>
+  <color name="green"        value="#73c48f"/>
+  
+  <color name="yellow_dark"  value="#cc9e2b"/>
+  <color name="orange_dark"  value="#be7704"/>
+  <color name="red_dark"     value="#db3400"/>
+  <color name="magenta_dark" value="#D93F73"/>
+  <color name="violet_dark"  value="#9c27b0"/>
+  <color name="blue_dark"    value="#505FB5"/>
+  <color name="cyan_dark"    value="#39939E"/>
+  <color name="green_dark"   value="#01967a"/>
+  
+  <color name="fg"           value="#574F4A"/>
+  <color name="accent"       value="#FAA41A"/>
+  <color name="primary"      value="#48B9C7"/>
+  <color name="bg"           value="#F5F5F5"/>
+  <color name="bg_lighter"   value="#FAFAFA"/>
+  <color name="base"         value="#E5E5E5"/>
+  <color name="fg_dark"      value="#F6F6F6"/>
+  <color name="accent_dark"  value="#BE7704"/>
+  <color name="primary_dark" value="#2C8691"/>
+  <color name="bg_dark"      value="#3F3B39"/>
+  <color name="base_dark"    value="#4C4845"/>
+
+  <color name="base_darker"  value="#e0e0e0"/>
+  <color name="bg_darker"    value="#999999"/>
+  <color name="fg_lighter"   value="#888888"/>
+
+  <!-- Global Settings -->
+  <style name="text"                        foreground="fg_dark" background="bg_dark"/>
+  <style name="selection"                   foreground="bg_dark" background="cyan_dark"/>
+  <style name="cursor"                      foreground="fg_dark"/>
+  <style name="current-line"                background="base_dark"/>
+  <style name="line-numbers"                foreground="fg_dark" background="base_dark"/>
+  <style name="background-pattern"          background="base_dark"/>
+
+  <!-- Bracket Matching -->
+  <style name="bracket-match"               foreground="fg_dark" background="primary_dark"/>
+  <style name="bracket-mismatch"            foreground="fg_dark" background="accent_dark"/>
+
+  <!-- Right Margin -->
+  <style name="right-margin"                foreground="fg_dark" background="base_dark"/>
+
+  <!-- Search Matching -->
+  <style name="search-match"                foreground="fg_dark" background="yellow_dark"/>
+
+  <!-- Comments -->
+  <style name="def:comment"                 foreground="bg_darker"/>
+  <style name="def:shebang"                 foreground="base_darker" bold="true"/>
+  <style name="def:doc-comment-element"     italic="true"/>
+
+  <!-- Constants -->
+  <style name="def:constant"                foreground="orange"/>
+  <style name="def:special-char"            foreground="yellow"/>
+
+  <!-- Identifiers -->
+  <style name="def:identifier"              foreground="green"/>
+
+  <!-- Statements -->
+  <style name="def:statement"               foreground="blue"/>
+
+  <!-- Types -->
+  <style name="def:type"                    foreground="cyan"/>
+
+  <!-- Operators -->
+  <style name="def:operator"                foreground="green"/>
+
+  <!-- Others -->
+  <style name="def:preprocessor"            foreground="violet"/>
+  <style name="def:error"                   foreground="red" bold="true"/>
+  <style name="def:note"                    foreground="magenta" bold="true"/>
+  <style name="def:underlined"              italic="true" underline="single"/>
+
+  <!-- Heading styles, uncomment to enable -->
+
+  <style name="def:heading0"                scale="5.0"/>
+  <style name="def:heading1"                scale="2.5"/>
+  <style name="def:heading2"                scale="2.0"/>
+  <style name="def:heading3"                scale="1.7"/>
+  <style name="def:heading4"                scale="1.5"/>
+  <style name="def:heading5"                scale="1.3"/>
+  <style name="def:heading6"                scale="1.2"/>
+
+</style-scheme>

--- a/usr/share/gtksourceview-4/styles/pop-light.xml
+++ b/usr/share/gtksourceview-4/styles/pop-light.xml
@@ -1,0 +1,118 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+  This file is part of GtkSourceView
+
+  Copyright (C) 2018 Ian Santopietro
+  Author: Ian Santopietro <isantop@gmail.com>
+
+  GtkSourceView is free software; you can redistribute it and/or
+  modify it under the terms of the GNU Lesser General Public
+  License as published by the Free Software Foundation; either
+  version 2.1 of the License, or (at your option) any later version.
+
+  GtkSourceView is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+  Lesser General Public License for more details.
+
+  You should have received a copy of the GNU Lesser General Public
+  License along with this library; if not, write to the Free Software
+  Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+
+-->
+<style-scheme id="pop-light" _name="Pop Light" version="1.0">
+  <author>Ian Santopietro</author>
+  <_description>Color scheme using Pop color palette</_description>
+
+  <!-- Pop Palette -->
+  <color name="yellow"       value="#ffce51"/>
+  <color name="orange"       value="#faa41a"/>
+  <color name="red"          value="#f15d22"/>
+  <color name="magenta"      value="#FF3077"/>
+  <color name="violet"       value="#D86EEB"/>
+  <color name="blue"         value="#8D9DF7"/>
+  <color name="cyan"         value="#48b9c7"/>
+  <color name="green"        value="#73c48f"/>
+  
+  <color name="yellow_dark"  value="#cc9e2b"/>
+  <color name="orange_dark"  value="#be7704"/>
+  <color name="red_dark"     value="#db3400"/>
+  <color name="magenta_dark" value="#D93F73"/>
+  <color name="violet_dark"  value="#9c27b0"/>
+  <color name="blue_dark"    value="#505FB5"/>
+  <color name="cyan_dark"    value="#39939E"/>
+  <color name="green_dark"   value="#01967a"/>
+  
+  <color name="fg"           value="#574F4A"/>
+  <color name="accent"       value="#FAA41A"/>
+  <color name="primary"      value="#48B9C7"/>
+  <color name="bg"           value="#F5F5F5"/>
+  <color name="bg_lighter"   value="#FAFAFA"/>
+  <color name="base"         value="#E5E5E5"/>
+  <color name="fg_dark"      value="#F6F6F6"/>
+  <color name="accent_dark"  value="#BE7704"/>
+  <color name="primary_dark" value="#2C8691"/>
+  <color name="bg_dark"      value="#3F3B39"/>
+  <color name="base_dark"    value="#4C4845"/>
+
+  <color name="base_darker"  value="#e0e0e0"/>
+  <color name="bg_darker"    value="#999999"/>
+  <color name="fg_lighter"   value="#888888"/>
+
+  <!-- Global Settings -->
+  <style name="text"                        foreground="fg" background="bg"/>
+  <style name="selection"                   foreground="bg" background="cyan_dark"/>
+  <style name="cursor"                      foreground="fg"/>
+  <style name="current-line"                background="base"/>
+  <style name="line-numbers"                foreground="fg" background="base"/>
+  <style name="background-pattern"          background="base_darker"/>
+
+  <!-- Bracket Matching -->
+  <style name="bracket-match"               foreground="fg" background="primary"/>
+  <style name="bracket-mismatch"            foreground="fg" background="accent"/>
+
+  <!-- Right Margin -->
+  <style name="right-margin"                foreground="fg" background="base"/>
+
+  <!-- Search Matching -->
+  <style name="search-match"                foreground="fg" background="yellow"/>
+
+  <!-- Comments -->
+  <style name="def:comment"                 foreground="fg_lighter"/>
+  <style name="def:shebang"                 foreground="fg_lighter" bold="true"/>
+  <style name="def:doc-comment-element"     italic="true"/>
+
+  <!-- Constants -->
+  <style name="def:constant"                foreground="orange_dark"/>
+  <style name="def:special-char"            foreground="yellow_dark"/>
+
+  <!-- Identifiers -->
+  <style name="def:identifier"              foreground="green_dark"/>
+
+  <!-- Statements -->
+  <style name="def:statement"               foreground="blue_dark"/>
+
+  <!-- Types -->
+  <style name="def:type"                    foreground="cyan_dark"/>
+
+  <!-- Operators -->
+  <style name="def:operator"                foreground="green_dark"/>
+
+  <!-- Others -->
+  <style name="def:preprocessor"            foreground="violet_dark"/>
+  <style name="def:error"                   foreground="red_dark" bold="true"/>
+  <style name="def:note"                    foreground="magenta_dark" bold="true"/>
+  <style name="def:underlined"              italic="true" underline="single"/>
+
+  <!-- Heading styles, uncomment to enable -->
+
+  <style name="def:heading0"                scale="5.0"/>
+  <style name="def:heading1"                scale="2.5"/>
+  <style name="def:heading2"                scale="2.0"/>
+  <style name="def:heading3"                scale="1.7"/>
+  <style name="def:heading4"                scale="1.5"/>
+  <style name="def:heading5"                scale="1.3"/>
+  <style name="def:heading6"                scale="1.2"/>
+
+</style-scheme>


### PR DESCRIPTION
This PR fixes our GtkSourceView styles in Gedit by also installing them for gtksourceview-4. It also re-adds our default override to the default settings package.

@brs17 For testing this, please log out or reboot, log in, and check that the default editor theme is set to Pop-Light in Gedit preferences (under "Editor & Colors")