### PR TITLE
Set GTK theme override for Firefox

### DIFF
--- a/usr/lib/firefox/defaults/pref/pop-default-settings.js
+++ b/usr/lib/firefox/defaults/pref/pop-default-settings.js
@@ -1,0 +1,1 @@
+pref("widget.content.gtk-theme-override", "Pop");


### PR DESCRIPTION
This should fix theming issues with dark mode in Firefox