### PR TITLE
Fix Neofetch output to display Pop! instead of Ubuntu

### DIFF
--- a/debian/pop-default-settings.postinst
+++ b/debian/pop-default-settings.postinst
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 set -e
 

--- a/debian/pop-default-settings.postinst
+++ b/debian/pop-default-settings.postinst
@@ -2,20 +2,28 @@
 
 set -e
 
+# Make sure this is in sync with prerm
+package=pop-default-settings
+diverts=(
+    "/etc/gdm3/custom.conf=/etc/pop-os/gdm3/custom.conf"
+    "/etc/lsb-release=/etc/pop-os/lsb-release"
+    "/etc/os-release=/etc/pop-os/os-release"
+    "/usr/lib/os-release=/etc/pop-os/os-release"
+)
+
 case "$1" in
     configure)
-        for f in lsb-release os-release
+        for divert in "${diverts[@]}"
         do
-            dpkg-divert --add --package pop-default-settings --rename --divert "/etc/$f.diverted" "/etc/$f"
-            dpkg-divert --add --package pop-default-settings --rename --divert "/usr/lib/$f.diverted" "/usr/lib/$f"
-            ln --force --relative --symbolic "/etc/pop-os/$f" "/etc/$f"
-            ln --force --relative --symbolic "/etc/pop-os/$f" "/usr/lib/$f"
-        done
+            source="${divert%%=*}"
+            dest="${divert#*=}"
 
-        for f in gdm3/custom.conf
-        do
-            dpkg-divert --add --package pop-default-settings --rename --divert "/etc/$f.diverted" "/etc/$f"
-            [ \! -e "/etc/$f" -o -L "/etc/$f" ] && ln --force --relative --symbolic "/etc/pop-os/$f" "/etc/$f"
+            dpkg-divert --add --package pop-default-settings --rename --divert "$source.diverted" "$source"
+
+            if [ -L "$source" -o ! -e "$source" ]
+            then
+                ln --force --relative --symbolic "$dest" "$source"
+            fi
         done
 
         # Add Pop proprietary repo if it is missing.

--- a/debian/pop-default-settings.postinst
+++ b/debian/pop-default-settings.postinst
@@ -7,7 +7,9 @@ case "$1" in
         for f in lsb-release os-release
         do
             dpkg-divert --add --package pop-default-settings --rename --divert "/etc/$f.diverted" "/etc/$f"
+            dpkg-divert --add --package pop-default-settings --rename --divert "/usr/lib/$f.diverted" "/usr/lib/$f"
             ln --force --relative --symbolic "/etc/pop-os/$f" "/etc/$f"
+            ln --force --relative --symbolic "/etc/pop-os/$f" "/usr/lib/$f"
         done
 
         for f in gdm3/custom.conf
@@ -15,7 +17,7 @@ case "$1" in
             dpkg-divert --add --package pop-default-settings --rename --divert "/etc/$f.diverted" "/etc/$f"
             [ \! -e "/etc/$f" -o -L "/etc/$f" ] && ln --force --relative --symbolic "/etc/pop-os/$f" "/etc/$f"
         done
-        
+
         # Add Pop proprietary repo if it is missing.
         RELEASE="$(lsb_release -cs)"
         REPO="deb http://apt.pop-os.org/proprietary ${RELEASE} main"

--- a/debian/pop-default-settings.prerm
+++ b/debian/pop-default-settings.prerm
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 set -e
 

--- a/debian/pop-default-settings.prerm
+++ b/debian/pop-default-settings.prerm
@@ -8,6 +8,10 @@ case "$1" in
         do
             [ -L "/etc/$f" ] && rm "/etc/$f"
             dpkg-divert --remove --package pop-default-settings --rename --divert "/etc/$f.diverted" "/etc/$f"
+            if [ -L "/usr/lib/$f" ]; then
+                rm "/usr/lib/$f"
+                dpkg-divert --remove --package pop-default-settings --rename --divert "/usr/lib/$f.diverted" "/usr/lib/$f"
+            fi
         done
         ;;
 

--- a/debian/pop-default-settings.prerm
+++ b/debian/pop-default-settings.prerm
@@ -2,15 +2,30 @@
 
 set -e
 
+# Make sure this is in sync with postinst
+package=pop-default-settings
+diverts=(
+    "/etc/gdm3/custom.conf=/etc/pop-os/gdm3/custom.conf"
+    "/etc/lsb-release=/etc/pop-os/lsb-release"
+    "/etc/os-release=/etc/pop-os/os-release"
+    "/usr/lib/os-release=/etc/pop-os/os-release"
+)
+
 case "$1" in
     remove)
-        for f in lsb-release os-release gdm3/custom.conf
+        for divert in "${diverts[@]}"
         do
-            [ -L "/etc/$f" ] && rm "/etc/$f"
-            dpkg-divert --remove --package pop-default-settings --rename --divert "/etc/$f.diverted" "/etc/$f"
-            if [ -L "/usr/lib/$f" ]; then
-                rm "/usr/lib/$f"
-                dpkg-divert --remove --package pop-default-settings --rename --divert "/usr/lib/$f.diverted" "/usr/lib/$f"
+            source="${divert%%=*}"
+            dest="${divert#*=}"
+
+            if [ "$(dpkg-divert --listpackage "$source")" == "$package" ]
+            then
+                if [ -L "$source" ]
+                then
+                    rm "$source"
+                fi
+
+                dpkg-divert --remove --package "$package" --rename --divert "$source.diverted" "$source"
             fi
         done
         ;;


### PR DESCRIPTION
In 19.04, `neofetch` and `lsb_release`, and possibly others, are now reading from `/usr/lib/os-release` instead of `/etc/os-release`. According to the freedesktop spec, `/etc/os-release` is supposed to take precedence over `/usr/lib/os-release`, and only fall back to `/usr/lib/os-release` if `/etc/os-release` is missing. `lsb_release` and `neofetch` seem to be exhibiting broken behavior in that regard.

This will add a symlink at `/usr/lib/os-release` so that applications using either `/etc/os-release` or `/usr/lib/os-release` will get the correct os-release.