### PR TITLE
apt.pop-os.org mirror for disco

### DIFF
--- a/etc/apt/preferences.d/pop-default-settings
+++ b/etc/apt/preferences.d/pop-default-settings
@@ -1,8 +1,4 @@
 Package: *
-Pin: origin apt.pop-os.org
-Pin-Priority: 600
-
-Package: *
 Pin: release o=LP-PPA-system76-pop
 Pin-Priority: 1001
 

--- a/etc/apt/preferences.d/pop-default-settings
+++ b/etc/apt/preferences.d/pop-default-settings
@@ -1,4 +1,8 @@
 Package: *
+Pin: origin apt.pop-os.org
+Pin-Priority: 600
+
+Package: *
 Pin: release o=LP-PPA-system76-pop
 Pin-Priority: 1001
 

--- a/etc/update-manager/release-upgrades.d/pop-default-settings.cfg
+++ b/etc/update-manager/release-upgrades.d/pop-default-settings.cfg
@@ -2,3 +2,4 @@
 system76_pop = http://ppa.launchpad.net/system76/pop/ubuntu/
 system76_proposed = http://ppa.launchpad.net/system76/proposed/ubuntu/
 system76_proprietary = http://apt.pop-os.org/proprietary/
+system76_ubuntu = http://apt.pop-os.org/ubuntu/


### PR DESCRIPTION
This will add the Ubuntu mirror at apt.pop-os.org/ubuntu to all 19.04 systems.