### PR TITLE
Set default vm.swappiness from 60 to 10

### DIFF
--- a/debian/conffiles
+++ b/debian/conffiles
@@ -1,1 +1,2 @@
 /etc/pop-os/gdm3/custom.conf
+/etc/sysctl.d/10-pop-default-settings.conf

--- a/etc/sysctl.d/10-pop-default-settings.conf
+++ b/etc/sysctl.d/10-pop-default-settings.conf
@@ -1,0 +1,1 @@
+vm.swappiness = 10


### PR DESCRIPTION
Any system with a SSD, or a sufficient amount of RAM, should avoid using swap until it is necessary. Solus is setting their default swappiness to 10, so it's likely a good idea that we do similarly here.

### Testing

- Before installing the updated package, `sysctl vm.swappiness` returns 60.
- After installing the package, running `sysctl --system` will reload the systctl parameters.
- `sysctl vm.swappiness` then should return 10.