### PR TITLE
Allow folder edits by only setting pop app folders on first login

### DIFF
--- a/usr/bin/pop-app-folders
+++ b/usr/bin/pop-app-folders
@@ -1,5 +1,10 @@
 #!/bin/sh
 
+if [ -e "${HOME}/.cache/pop-app-folders" ]
+then
+    exit 0
+fi
+
 APP_FOLDER="org.gnome.desktop.app-folders.folder:/org/gnome/desktop/app-folders/folders/Pop"
 
 gsettings reset-recursively "${APP_FOLDER}-Office/"
@@ -50,4 +55,4 @@ gsettings set "${APP_FOLDER}-Utility/" apps "[
 'yelp.desktop'
 ]"
 
-gsettings reset org.gnome.desktop.interface scaling-factor
+touch "${HOME}/.cache/pop-app-folders"


### PR DESCRIPTION
This should fix https://github.com/pop-os/pop/issues/583

`gsettings reset org.gnome.desktop.interface scaling-factor` was removed as it is no longer useful with newer versions of mutter and GNOME