### PR TITLE
Bionic: Fix Popsicle desktop name

### DIFF
--- a/usr/bin/pop-app-folders
+++ b/usr/bin/pop-app-folders
@@ -37,13 +37,13 @@ gsettings set "${APP_FOLDER}-Utility/" name "X-GNOME-Utilities.directory"
 gsettings set "${APP_FOLDER}-Utility/" translate true
 gsettings set "${APP_FOLDER}-Utility/" apps "[
 'com.github.donadigo.eddy.desktop',
+'com.system76.Popsicle.desktop',
 'eog.desktop',
 'evince.desktop',
 'file-roller.desktop',
 'gucharmap.desktop',
 'org.gnome.font-viewer.desktop',
 'org.gnome.Screenshot.desktop',
-'popsicle.desktop',
 'simple-scan.desktop',
 'totem.desktop',
 'yelp.desktop'


### PR DESCRIPTION
Fixes (to me) the most blaring issue of https://github.com/pop-os/default-settings/issues/61 that Popsicle is not in the correct folder in the Activities menu.