### PR TITLE
fix: Prevent bluetooth from preventing laptops from staying suspended

### DIFF
--- a/usr/lib/systemd/systemd-sleep/bluetooth-suspend.sh
+++ b/usr/lib/systemd/systemd-sleep/bluetooth-suspend.sh
@@ -1,0 +1,12 @@
+#!/bin/sh
+
+RESUME_FILE=/tmp/enable-bluetooth-on-resume
+
+if test "${1}" = "pre"; then
+  systemctl is-enabled bluetooth && touch ${RESUME_FILE}
+  systemctl disable bluetooth
+  systemctl stop bluetooth
+elif test "${1}" = "post"; then
+  test -e ${RESUME_FILE} \
+    && (systemctl enable bluetooth && sleep 3 && systemctl start bluetooth; rm ${RESUME_FILE})
+fi


### PR DESCRIPTION
I've been hearing that the bluetooth service causes a number of laptops, including the oryp5, to be unable to remain suspended. A script similar to this is being passed around as a workaround to the problem, so it might be useful to include this workaround by default. This will disable and stop the bluetooth service immediately pre-suspension, and then re-enable and start it post-suspension. A file is used to determine if the bluetooth service was enabled prior to suspension, so that it will only be enabled and started if it was previously-enabled