### PR TITLE
Put gnome-shell-extensions-prefs into Utility folder

### DIFF
--- a/usr/bin/pop-app-folders
+++ b/usr/bin/pop-app-folders
@@ -58,6 +58,7 @@ gsettings set "${APP_FOLDER}-Utility/" apps "[
 'gucharmap.desktop',
 'info.desktop',
 'org.gnome.Evince.desktop',
+'org.gnome.Extensions.desktop',
 'org.gnome.FileRoller.desktop',
 'org.gnome.font-viewer.desktop',
 'org.gnome.Screenshot.desktop',


### PR DESCRIPTION
Fixes https://github.com/pop-os/default-settings/issues/76