### PR TITLE
fix: Preinstall Pop and Pop-Dark Flatpak GTK Themes

### DIFF
--- a/usr/bin/pop-flatpak-repos
+++ b/usr/bin/pop-flatpak-repos
@@ -1,9 +1,20 @@
 #!/bin/sh
 
-if [ -e "${HOME}/.cache/pop-flatpak-repos" ]
+CACHE_PATH="${HOME}/.cache/pop-flatpak-repos"
+
+if [ -e "${CACHE_PATH}" ]
 then
-    exit 0
+    CACHE_VERSION="$(cat "${CACHE_PATH}")"
+    if [ -z "${CACHE_VERSION}" ]
+    then
+        CACHE_VERSION="0"
+    fi
+else
+    CACHE_VERSION="0"
 fi
+
+if [ "${CACHE_VERSION}" -lt "1" ]
+then
 
 if command -v flatpak >/dev/null
 then
@@ -12,3 +23,7 @@ then
         && flatpak install --user flathub org.gtk.Gtk3theme.Pop-dark \
         && touch "${HOME}/.cache/pop-flatpak-repos"
 fi
+
+fi
+
+echo "1" > "${CACHE_PATH}"

--- a/usr/bin/pop-flatpak-repos
+++ b/usr/bin/pop-flatpak-repos
@@ -7,6 +7,8 @@ fi
 
 if command -v flatpak >/dev/null
 then
-    flatpak remote-add --user --if-not-exists flathub /etc/pop-os/flatpak/flathub.flatpakrepo &&
-    touch "${HOME}/.cache/pop-flatpak-repos"
+    flatpak remote-add --user --if-not-exists flathub /etc/pop-os/flatpak/flathub.flatpakrepo \
+        && flatpak install --user flathub org.gtk.Gtk3theme.Pop \
+        && flatpak install --user flathub org.gtk.Gtk3theme.Pop-dark \
+        && touch "${HOME}/.cache/pop-flatpak-repos"
 fi


### PR DESCRIPTION
Adds a check on startup to install the Pop and Pop-Dark GTK themes from Flathub.

Closes https://github.com/pop-os/pop/issues/972