### PR TITLE
WIP: switch to apt.pop-os.org for Ubuntu packages

### DIFF
--- a/debian/pop-default-settings.postinst
+++ b/debian/pop-default-settings.postinst
@@ -83,6 +83,15 @@ case "$1" in
             fi
         done
 
+        shopt -s nullglob
+        for file in /etc/apt/sources.list /etc/apt/sources.list.d/*.list
+        do
+            # Convert to apt.pop-os.org mirror, if using us.archive.ubuntu.com
+            sed -i 's|us.archive.ubuntu.com/ubuntu|apt.pop-os.org/ubuntu|' "${file}"
+            # Convert to apt.pop-os.org/release if using PPA
+            sed -i 's|ppa.launchpad.net/system76/pop/ubuntu|apt.pop-os.org/release|' "${file}"
+        done
+
         # Add Pop proprietary repo if it is missing.
         RELEASE="$(lsb_release -cs)"
         REPO="deb http://apt.pop-os.org/proprietary ${RELEASE} main"

--- a/debian/pop-default-settings.prerm
+++ b/debian/pop-default-settings.prerm
@@ -32,6 +32,13 @@ case "$1" in
                 dpkg-divert --remove --package "$package" --rename --divert "$source.diverted" "$source"
             fi
         done
+
+        shopt -s nullglob
+        for file in /etc/apt/sources.list /etc/apt/sources.list.d/*.list
+        do
+            # Convert to us.archive.ubuntu.com if using apt.pop-os.org mirror
+            sed -i 's|apt.pop-os.org/ubuntu|us.archive.ubuntu.com/ubuntu|' "$file"
+        done
         ;;
 
     *)

--- a/etc/apt/preferences.d/pop-default-settings
+++ b/etc/apt/preferences.d/pop-default-settings
@@ -1,7 +1,3 @@
 Package: *
-Pin: release o=LP-PPA-system76-pop
-Pin-Priority: 1001
-
-Package: *
-Pin: release o=LP-PPA-system76-proposed
+Pin: release o=pop-os-release
 Pin-Priority: 1001


### PR DESCRIPTION
This will swap the Ubuntu sources to apt.pop-os.org. Can be tested on focal which the partial mirror is syncing. This will be a draft until a full mirror is created