### PR TITLE
Fix python-apt mirror link

### DIFF
--- a/debian/pop-default-settings.links
+++ b/debian/pop-default-settings.links
@@ -1,2 +1,2 @@
 usr/share/python-apt/templates/Ubuntu.info usr/share/python-apt/templates/Pop.info
-usr/share/python-apt/templates/Ubuntu.info usr/share/python-apt/templates/Pop.mirrors
+usr/share/python-apt/templates/Ubuntu.mirrors usr/share/python-apt/templates/Pop.mirrors


### PR DESCRIPTION
Not sure what issues this caused, but Pop.mirrors was linked to Ubuntu.info instead of Ubuntu.mirrors