### PR TITLE
fix(firefox): Unset layers accceleration and enable gfx.xrender instead

### DIFF
--- a/usr/lib/firefox/defaults/pref/pop-default-settings.js
+++ b/usr/lib/firefox/defaults/pref/pop-default-settings.js
@@ -1,2 +1,2 @@
-pref("layers.acceleration.force-enabled", true);
+pref("gfx.xrender.enabled", true);
 pref("widget.content.gtk-theme-override", "Pop");

--- a/usr/lib/firefox/defaults/pref/pop-default-settings.js
+++ b/usr/lib/firefox/defaults/pref/pop-default-settings.js
@@ -1,2 +1,3 @@
 pref("gfx.xrender.enabled", true);
+pref("layout.frame_rate", 144);
 pref("widget.content.gtk-theme-override", "Pop");


### PR DESCRIPTION
FIx disappearing windows and choppy refresh rate