### PR TITLE
fix(proprietary): add the Deb822-format repository on groovy

### DIFF
--- a/debian/pop-default-settings.postinst
+++ b/debian/pop-default-settings.postinst
@@ -68,6 +68,15 @@ fOyJI22NfTI+3SMAsMQ8L+WVQI+58bu7+iEqoEfHCXikE8BtTbJAN4Oob1lrjfOe
 -----END PGP PUBLIC KEY BLOCK-----
 "
 
+RELEASE="$(lsb_release -cs)"
+REPO="http://apt.pop-os.org/proprietary"
+SOURCE="X-Repolib-Name: Pop_OS Applications
+Enabled: yes
+Types: deb
+URIs: ${REPO}
+Suites: ${RELEASE}
+Components: main"
+
 case "$1" in
     configure)
         for divert in "${diverts[@]}"
@@ -84,12 +93,10 @@ case "$1" in
         done
 
         # Add Pop proprietary repo if it is missing.
-        RELEASE="$(lsb_release -cs)"
-        REPO="deb http://apt.pop-os.org/proprietary ${RELEASE} main"
-        if ! grep "${REPO}" /etc/apt/sources.list > /dev/null
+        if ! grep -r "${REPO}" /etc/apt/ > /dev/null
         then
             echo "${ISO_KEY}" | apt-key add -
-            echo "${REPO}" >> /etc/apt/sources.list
+            echo "${SOURCE}" > /etc/apt/sources.list.d/pop-os-apps.sources
         fi
         ;;
 

--- a/debian/pop-default-settings.postinst
+++ b/debian/pop-default-settings.postinst
@@ -93,7 +93,8 @@ case "$1" in
         done
 
         # Add Pop proprietary repo if it is missing.
-        if ! grep -r "${REPO}" /etc/apt/ > /dev/null
+        shopt -s nullglob
+        grep "${REPO}" /etc/apt/sources.list{,.d/*.list,.d/*.source}
         then
             echo "${ISO_KEY}" | apt-key add -
             echo "${SOURCE}" > /etc/apt/sources.list.d/pop-os-apps.sources

--- a/debian/pop-default-settings.postinst
+++ b/debian/pop-default-settings.postinst
@@ -94,7 +94,7 @@ case "$1" in
 
         # Add Pop proprietary repo if it is missing.
         shopt -s nullglob
-        if ! grep "${REPO}" /etc/apt/sources.list{,.d/*.list,.d/*.source}
+        if ! grep "${REPO}" /etc/apt/sources.list{,.d/*.list,.d/*.sources}
         then
             echo "${ISO_KEY}" | apt-key add -
             echo "${SOURCE}" > /etc/apt/sources.list.d/pop-os-apps.sources

--- a/debian/pop-default-settings.postinst
+++ b/debian/pop-default-settings.postinst
@@ -94,7 +94,7 @@ case "$1" in
 
         # Add Pop proprietary repo if it is missing.
         shopt -s nullglob
-        grep "${REPO}" /etc/apt/sources.list{,.d/*.list,.d/*.source}
+        if ! grep "${REPO}" /etc/apt/sources.list{,.d/*.list,.d/*.source}
         then
             echo "${ISO_KEY}" | apt-key add -
             echo "${SOURCE}" > /etc/apt/sources.list.d/pop-os-apps.sources


### PR DESCRIPTION
Since the ISO is being built with the DEB822-format sources (including the Apps repo),
the postinst script needs to be adapted to add it as well if it isn't found. Otherwise,
the ISO ends up getting build with two copies of the repo, causing APT errors in the
ISO and installed system.

It attempts to look for matches anywhere in the apt configuration, so it shouldn't add a duplicate repo if it's already configured in either the sources.list file or anywhere in /etc/apt/sources.list.d

Required for pop-os/iso#267