### PR TITLE
Convert to DEB822 sources on upgrades to Groovy

### DIFF
--- a/debian/pop-default-settings.postinst
+++ b/debian/pop-default-settings.postinst
@@ -68,6 +68,15 @@ fOyJI22NfTI+3SMAsMQ8L+WVQI+58bu7+iEqoEfHCXikE8BtTbJAN4Oob1lrjfOe
 -----END PGP PUBLIC KEY BLOCK-----
 "
 
+RELEASE="$(lsb_release -cs)"
+REPO="http://apt.pop-os.org/proprietary"
+SOURCE="X-Repolib-Name: Pop_OS Applications
+Enabled: yes
+Types: deb
+URIs: ${REPO}
+Suites: ${RELEASE}
+Components: main"
+
 case "$1" in
     configure)
         for divert in "${diverts[@]}"
@@ -84,12 +93,10 @@ case "$1" in
         done
 
         # Add Pop proprietary repo if it is missing.
-        RELEASE="$(lsb_release -cs)"
-        REPO="deb http://apt.pop-os.org/proprietary ${RELEASE} main"
-        if ! grep "${REPO}" /etc/apt/sources.list > /dev/null
+        if ! grep -r "${REPO}" /etc/apt/ > /dev/null
         then
             echo "${ISO_KEY}" | apt-key add -
-            echo "${REPO}" >> /etc/apt/sources.list
+            echo "${SOURCE}" > /etc/apt/sources.list.d/pop-os-apps.sources
         fi
         ;;
 

--- a/debian/pop-default-settings.postinst
+++ b/debian/pop-default-settings.postinst
@@ -93,7 +93,8 @@ case "$1" in
         done
 
         # Add Pop proprietary repo if it is missing.
-        if ! grep -r "${REPO}" /etc/apt/ > /dev/null
+        shopt -s nullglob
+        grep "${REPO}" /etc/apt/sources.list{,.d/*.list,.d/*.source}
         then
             echo "${ISO_KEY}" | apt-key add -
             echo "${SOURCE}" > /etc/apt/sources.list.d/pop-os-apps.sources

--- a/debian/pop-default-settings.postinst
+++ b/debian/pop-default-settings.postinst
@@ -94,7 +94,7 @@ case "$1" in
 
         # Add Pop proprietary repo if it is missing.
         shopt -s nullglob
-        if ! grep "${REPO}" /etc/apt/sources.list{,.d/*.list,.d/*.source}
+        if ! grep "${REPO}" /etc/apt/sources.list{,.d/*.list,.d/*.sources}
         then
             echo "${ISO_KEY}" | apt-key add -
             echo "${SOURCE}" > /etc/apt/sources.list.d/pop-os-apps.sources

--- a/debian/pop-default-settings.postinst
+++ b/debian/pop-default-settings.postinst
@@ -77,6 +77,14 @@ URIs: ${REPO}
 Suites: ${RELEASE}
 Components: main"
 
+SYS_REPO="http://us.archive.ubuntu.com/ubuntu/"
+SYS_SOURCE="X-Repolib-Name: Pop_OS System Sources
+Enabled: yes
+Types: deb deb-src
+URIs: ${SYS_REPO}
+Suites: ${RELEASE} ${RELEASE}-security ${RELEASE}-updates ${RELEASE}-backports
+Components: main restricted universe multiverse"
+
 case "$1" in
     configure)
         for divert in "${diverts[@]}"
@@ -99,8 +107,20 @@ case "$1" in
             echo "${ISO_KEY}" | apt-key add -
             echo "${SOURCE}" > /etc/apt/sources.list.d/pop-os-apps.sources
         fi
-        ;;
 
+        # Convert system sources from one-line format to DEB822, if present
+        if grep "ubuntu.com" /etc/apt/sources.list # Generous matching, be more specific if found
+        then
+            # Remove system sources from sources.list
+            sed -i '/.*archive.ubuntu.com.*$/d' /etc/apt/sources.list
+            sed -i '/.*security.ubuntu.com.*$/d' /etc/apt/sources.list # Needed if this was added by software-properties
+        fi
+        # Look for existing system sources, and create if not found
+        if [ ! -f /etc/apt/sources.list.d/system.sources ]
+        then
+            echo "${SYS_SOURCE}" > /etc/apt/sources.list.d/system.sources
+        fi
+        ;;
     *)
         ;;
 esac

--- a/debian/pop-default-settings.postinst
+++ b/debian/pop-default-settings.postinst
@@ -94,7 +94,7 @@ case "$1" in
 
         # Add Pop proprietary repo if it is missing.
         shopt -s nullglob
-        grep "${REPO}" /etc/apt/sources.list{,.d/*.list,.d/*.source}
+        if ! grep "${REPO}" /etc/apt/sources.list{,.d/*.list,.d/*.source}
         then
             echo "${ISO_KEY}" | apt-key add -
             echo "${SOURCE}" > /etc/apt/sources.list.d/pop-os-apps.sources


### PR DESCRIPTION
Adds a small conversion item in the postinst that will remove Ubuntu/Pop Sources from the sources.list file and add a default system.sources file in sources.list.d