### PR TITLE
Add custom /etc/legal to mention Pop!_OS instead of Ubuntu

### DIFF
--- a/debian/pop-default-settings.postinst
+++ b/debian/pop-default-settings.postinst
@@ -8,6 +8,7 @@ diverts=(
     "/etc/gdm3/custom.conf=/etc/pop-os/gdm3/custom.conf"
     "/etc/issue=/etc/pop-os/issue"
     "/etc/issue.net=/etc/pop-os/issue.net"
+    "/etc/legal=/etc/pop-os/legal"
     "/etc/update-motd.d/10-help-text=/etc/pop-os/update-motd.d/10-help-text"
     "/etc/update-motd.d/50-motd-news=/etc/pop-os/update-motd.d/50-motd-news"
     "/etc/lsb-release=/etc/pop-os/lsb-release"

--- a/debian/pop-default-settings.prerm
+++ b/debian/pop-default-settings.prerm
@@ -8,6 +8,7 @@ diverts=(
     "/etc/gdm3/custom.conf=/etc/pop-os/gdm3/custom.conf"
     "/etc/issue=/etc/pop-os/issue"
     "/etc/issue.net=/etc/pop-os/issue.net"
+    "/etc/legal=/etc/pop-os/legal"
     "/etc/update-motd.d/10-help-text=/etc/pop-os/update-motd.d/10-help-text"
     "/etc/update-motd.d/50-motd-news=/etc/pop-os/update-motd.d/50-motd-news"
     "/etc/lsb-release=/etc/pop-os/lsb-release"

--- a/etc/pop-os/legal
+++ b/etc/pop-os/legal
@@ -1,0 +1,8 @@
+
+The programs included with the Pop!_OS system are free software;
+the exact distribution terms for each program are described in the
+individual files in /usr/share/doc/*/copyright.
+
+Pop!_OS comes with ABSOLUTELY NO WARRANTY, to the extent permitted by
+applicable law.
+


### PR DESCRIPTION
I noticed a copyright disclaimer with the MOTD, which mentioned Ubuntu (which seemed inconsistent).

It took me some time to figure out why this appeared that one time. I guess that was the first time I logged into a terminal after clearing `~/.cache`. It seems Ubuntu patches `pam_motd.so` to display `/etc/legal` on first login, and create  `~/.cache/motd.legal-displayed` to prevent it from appearing again.

To see the message, just remove `~/.cache/motd.legal-displayed` and login to a terminal.

Example:

```
Welcome to Pop!_OS 20.04 LTS (GNU/Linux 5.4.0-7642-generic x86_64)

 * Homepage: https://pop.system76.com
 * Support:  https://support.system76.com


The programs included with the Pop!_OS system are free software;
the exact distribution terms for each program are described in the
individual files in /usr/share/doc/*/copyright.

Pop!_OS comes with ABSOLUTELY NO WARRANTY, to the extent permitted by
applicable law.

Last login: Tue Oct  6 12:37:46 2020 from ::1
```

If this is approved, I will cherry-pick into `master_groovy` as well.