### PR TITLE
fix: Set the default repolib mirror to SYS_REPO

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -19,6 +19,6 @@ Depends: ${misc:Depends},
          pop-theme,
          pop-wallpapers,
          software-properties-common,
-         python3-repolib (>=1.4.0),
+         python3-repolib (>> 1.3.9),
 Description: default settings for the Pop desktop
  This package contains the default settings used by Pop.

--- a/debian/control
+++ b/debian/control
@@ -19,5 +19,6 @@ Depends: ${misc:Depends},
          pop-theme,
          pop-wallpapers,
          software-properties-common,
+         python3-repolib (>=1.4.0),
 Description: default settings for the Pop desktop
  This package contains the default settings used by Pop.

--- a/debian/pop-default-settings.postinst
+++ b/debian/pop-default-settings.postinst
@@ -84,7 +84,8 @@ Enabled: yes
 Types: deb deb-src
 URIs: ${SYS_REPO}
 Suites: ${RELEASE} ${RELEASE}-security ${RELEASE}-updates ${RELEASE}-backports
-Components: main restricted universe multiverse"
+Components: main restricted universe multiverse
+X-Repolib-Default-Mirror: ${SYS_REPO}"
 
 case "$1" in
     configure)
@@ -131,6 +132,9 @@ case "$1" in
         then
             echo "${SYS_SOURCE}" > /etc/apt/sources.list.d/system.sources
         fi
+
+        # Set the Vendor-recommended default mirror:
+        apt-manage modify system --default-mirror "${SYS_REPO}"
         ;;
     *)
         ;;


### PR DESCRIPTION
This ensures that users can reset their mirrors to the default if they accidentally
break something. Also adds repolib as a dependency, for performing the installation.

Requires pop-os/repolib#23