### PR TITLE
Switch to using webrender for Firefox (20.10)

### DIFF
--- a/usr/lib/firefox/defaults/pref/pop-default-settings.js
+++ b/usr/lib/firefox/defaults/pref/pop-default-settings.js
@@ -1,3 +1,2 @@
-pref("gfx.xrender.enabled", true);
-pref("layout.frame_rate", 144);
+pref("gfx.webrender.all", true);
 pref("widget.content.gtk-theme-override", "Pop");

--- a/usr/lib/firefox/defaults/pref/pop-default-settings.js
+++ b/usr/lib/firefox/defaults/pref/pop-default-settings.js
@@ -1,2 +1,3 @@
 pref("gfx.webrender.all", true);
+pref("layout.frame_rate", 144);
 pref("widget.content.gtk-theme-override", "Pop");


### PR DESCRIPTION
This may require a change to the NVIDIA driver as well to enable NVreg_PreserveVideoMemoryAllocations=1