### PR TITLE
firefox: Do not enable xrender, or set `layout.frame_rate`

### DIFF
--- a/usr/lib/firefox/defaults/pref/pop-default-settings.js
+++ b/usr/lib/firefox/defaults/pref/pop-default-settings.js
@@ -1,3 +1,1 @@
-pref("gfx.xrender.enabled", true);
-pref("layout.frame_rate", 144);
 pref("widget.content.gtk-theme-override", "Pop");


### PR DESCRIPTION
Xrender appears to be deprecated and have issues.

Instead of setting this here, we can have model specific fixes in system76-driver.

See also https://github.com/pop-os/system76-driver/pull/166.

Corresponding groovy PR: https://github.com/pop-os/default-settings/pull/107