### PR TITLE
Firefox: disable recommended articles from Pocket on New Tab page by default

### DIFF
--- a/usr/lib/firefox/browser/defaults/preferences/pop-default-settings.js
+++ b/usr/lib/firefox/browser/defaults/preferences/pop-default-settings.js
@@ -1,0 +1,1 @@
+pref("browser.newtabpage.activity-stream.feeds.section.topstories", false);

--- a/usr/lib/firefox/defaults/pref/pop-default-settings.js
+++ b/usr/lib/firefox/defaults/pref/pop-default-settings.js
@@ -1,2 +1,2 @@
 pref("widget.content.gtk-theme-override", "Pop");
-pref("browser.newtabpage.activity-stream.feeds.section.topstories", false);
+pref("browser.newtabpage.activity-stream.feeds.section.topstories", "false");

--- a/usr/lib/firefox/defaults/pref/pop-default-settings.js
+++ b/usr/lib/firefox/defaults/pref/pop-default-settings.js
@@ -1,2 +1,1 @@
 pref("widget.content.gtk-theme-override", "Pop");
-pref("browser.newtabpage.activity-stream.feeds.section.topstories", "false");

--- a/usr/lib/firefox/defaults/pref/pop-default-settings.js
+++ b/usr/lib/firefox/defaults/pref/pop-default-settings.js
@@ -1,1 +1,2 @@
 pref("widget.content.gtk-theme-override", "Pop");
+pref("browser.newtabpage.activity-stream.feeds.section.topstories", false);


### PR DESCRIPTION
This PR is intended to remove the "Recommended by Pocket" section of the New Tab page in Firefox by default. (For users who enjoy the selection of content, it can be turned back on using the checkbox in the Preferences page.)