### PR TITLE
fix: Set GTK IM module to ibus

### DIFF
--- a/etc/profile.d/pop-im-ibus.sh
+++ b/etc/profile.d/pop-im-ibus.sh
@@ -1,0 +1,3 @@
+export GTK_IM_MODULE="ibus"
+export QT_IM_MODULE="ibus"
+export XMODIFIERS="@im=ibus"


### PR DESCRIPTION
Part 1 of fixing the emoji ibus shortcut