### PR TITLE
fix: Set reasonable size for dirty bytes parameters

### DIFF
--- a/etc/sysctl.d/10-pop-default-settings.conf
+++ b/etc/sysctl.d/10-pop-default-settings.conf
@@ -1,1 +1,3 @@
 vm.swappiness = 10
+vm.dirty_bytes = 16777216
+vm.dirty_background_bytes = 4194304


### PR DESCRIPTION
Importing patch from Focal to reduce stutter and freezes that can happen on Linux from excessive I/O on file transfers.

> The kernel default is to buffer up to 10% of system RAM before flushing writes to the disk, which is insane. By setting a reasonable number of bytes for the `dirty_bytes` parameter, we can avoid sending the system into OOM during a large file transfer.
> 
> https://lwn.net/Articles/572911/