### PR TITLE
fix: Raise dirty bytes to 256MB to fix btrfs performance

### DIFF
--- a/etc/sysctl.d/10-pop-default-settings.conf
+++ b/etc/sysctl.d/10-pop-default-settings.conf
@@ -1,3 +1,3 @@
 vm.swappiness = 10
-vm.dirty_bytes = 16777216
-vm.dirty_background_bytes = 4194304
+vm.dirty_bytes = 268435456
+vm.dirty_background_bytes = 134217728


### PR DESCRIPTION
Closes #111 

Check if a system with only magnetic storage copying large files across partitions/networks can do so successfully without stalling.