### PR TITLE
fix: Missing app icons / default application selection from nix installs

### DIFF
--- a/etc/profile.d/pop-nix.sh
+++ b/etc/profile.d/pop-nix.sh
@@ -1,0 +1,6 @@
+# Enables application icons to appear
+if command -v nix-env > /dev/null; then
+  DEFAULT_PROFILE=/nix/var/nix/profiles/default/share
+  USER_PROFILE=/nix/var/nix/profiles/per-user/${USER}/profile/share
+  export XDG_DATA_DIRS=${DEFAULT_PROFILE}:${USER_PROFILE}:${XDG_DATA_DIRS}
+fi


### PR DESCRIPTION
Useful until we have better nix packaging for Pop.

Requires logging out and logging back in after this script is added.

Can be tested by installing some applications with nix-env and then checking if the launcher shows the icons.