### PR TITLE
fix: Disable DPMS times to fix screens powering constantly

### DIFF
--- a/usr/share/X11/xorg.conf.d/10-pop-dpms.conf
+++ b/usr/share/X11/xorg.conf.d/10-pop-dpms.conf
@@ -1,0 +1,6 @@
+Section "ServerFlags"
+    Option "StandbyTime" "0"
+    Option "SuspendTime" "0"
+    Option "OffTime" "0"
+    Option "BlankTime" "0"
+EndSection


### PR DESCRIPTION
The feature seems to be poorly-supported in 21.10 given the amount of
bug reports I'm seeing about this lately. I have also seen it happening. With this option enabled, displays will power off even when the user is actively interacting with the system, and it doesn't adhere to the screen blank setting in GNOME.

Fixes https://github.com/pop-os/pop/issues/2104

https://www.reddit.com/r/pop_os/comments/ry5c6r/monitor_goes_off_after_few_seconds_of_inactivity/