### PR TITLE
fix: Limit journald logs to 100M

### DIFF
--- a/usr/lib/systemd/journald.conf.d/pop.conf
+++ b/usr/lib/systemd/journald.conf.d/pop.conf
@@ -1,0 +1,2 @@
+[Journal]
+SystemMaxUse=1000M


### PR DESCRIPTION
Thoughts on lowering the default of 10% disk capacity for logs? Value can still be overridden in `/etc/systemd/journald.conf`.