### PR TITLE
fix: pipewire-media-session conflict

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -19,5 +19,6 @@ Depends: ${misc:Depends},
          python3-repolib (>> 1.3.9),
          ubuntu-minimal,
          ubuntu-standard,
+Conflicts: pipewire-media-session
 Description: default settings for Pop OS
  This package contains the default settings used by Pop.


### PR DESCRIPTION
This should fix upgrades that had `pipewire-media-session` installed failing to install the pop-default-settings package.