### PR TITLE
Add bluetooth suspend/resume script

### DIFF
--- a/debian/pop-default-settings.install
+++ b/debian/pop-default-settings.install
@@ -1,2 +1,3 @@
 etc
+lib
 usr

--- a/lib/systemd/system-sleep/pop-default-settings_bluetooth-suspend
+++ b/lib/systemd/system-sleep/pop-default-settings_bluetooth-suspend
@@ -1,0 +1,17 @@
+#!/bin/sh
+
+set -e
+
+#TODO: save rfkill state?
+case "$2" in
+    suspend | hybrid-sleep)
+        case "$1" in
+            pre)
+				rfkill block bluetooth
+                ;;
+            post)
+				rfkill unblock bluetooth
+                ;;
+        esac
+        ;;
+esac


### PR DESCRIPTION
A simple script that just turns off bluetooth when suspending and turns it on when resuming. Could be improved by saving the device state before resume and restoring it.