### PR TITLE
Use apt.pop-os.org for Ubuntu mirror

### DIFF
--- a/debian/pop-default-settings.postinst
+++ b/debian/pop-default-settings.postinst
@@ -141,6 +141,8 @@ case "$1" in
         # Convert to apt.pop-os.org/release if using PPA
         for file in /etc/apt/sources.list{,.d/*.list,.d/*.sources}
         do
+            # Convert to apt.pop-os.org mirror, if using us.archive.ubuntu.com
+            sed -i 's|us.archive.ubuntu.com/ubuntu|apt.pop-os.org/ubuntu|' "${file}"
             # Convert to apt.pop-os.org/release if using PPA
             sed -i 's|ppa.launchpad.net/system76/pop/ubuntu|apt.pop-os.org/release|' "${file}"
         done

--- a/debian/pop-default-settings.prerm
+++ b/debian/pop-default-settings.prerm
@@ -33,6 +33,13 @@ case "$1" in
                 dpkg-divert --remove --package "$package" --rename --divert "$source.diverted" "$source"
             fi
         done
+
+        shopt -s nullglob
+        for file in /etc/apt/sources.list /etc/apt/sources.list.d/*.list
+        do
+            # Convert to us.archive.ubuntu.com if using apt.pop-os.org mirror
+            sed -i 's|apt.pop-os.org/ubuntu|us.archive.ubuntu.com/ubuntu|' "$file"
+        done
         ;;
 
     *)


### PR DESCRIPTION
This will switch users to from us.archive.ubuntu.com/ubuntu to apt.pop-os.org/ubuntu for the Ubuntu mirror. Needs extended testing.