### PR TITLE
bluetooth suspend fix with save rfkill state

### DIFF
--- a/lib/systemd/system-sleep/pop-default-settings_bluetooth-suspend
+++ b/lib/systemd/system-sleep/pop-default-settings_bluetooth-suspend
@@ -2,15 +2,19 @@
 
 set -e
 
-#TODO: save rfkill state?
 case "$2" in
     suspend | hybrid-sleep)
         case "$1" in
             pre)
-				rfkill block bluetooth
+                if [ $(cat /var/lib/systemd/rfkill/*bluetooth) -eq 1 ]; then
+                    > /home/$USER/blocked.bt
+                elif [ $(cat /var/lib/systemd/rfkill/*bluetooth) -eq 0 ]; then
+                    rfkill block bluetooth
+                fi
                 ;;
             post)
-				rfkill unblock bluetooth
+                test ! -f /home/$USER/blocked.bt && rfkill unblock bluetooth
+                rm /home/$USER/blocked.bt
                 ;;
         esac
         ;;


### PR DESCRIPTION
This extends the original scripts functionality by creating a temporary file before suspend if the user has turned off bluetooth. The file is removed after resume. This is to prevent the script from turning bluetooth back on after a suspend/resume cycle if it has been intentionally turned off by the user. 

May resolve https://github.com/pop-os/default-settings/issues/143