### PR TITLE
fix: bluetooth save state

### DIFF
--- a/lib/systemd/system-sleep/pop-default-settings_bluetooth-suspend
+++ b/lib/systemd/system-sleep/pop-default-settings_bluetooth-suspend
@@ -2,19 +2,26 @@
 
 set -e
 
+BT_BLOCK_PATH=/run/bluetooth.blocked
+BT_STATES_PATH=/var/lib/systemd/rfkill/
+BT_TMP_PATH=/tmp/
+
 case "$2" in
     suspend | hybrid-sleep)
         case "$1" in
             pre)
-                if [ $(cat /var/lib/systemd/rfkill/*bluetooth) -eq 1 ]; then
-                    > /home/$USER/blocked.bt
-                elif [ $(cat /var/lib/systemd/rfkill/*bluetooth) -eq 0 ]; then
+                if rfkill -o ID,TYPE,SOFT | grep -q -E 'bluetooth\s+unblocked'; then
+                    cp "$BT_STATES_PATH"*bluetooth "$BT_TMP_PATH"
                     rfkill block bluetooth
+                else
+                    > "$BT_BLOCK_PATH"
                 fi
                 ;;
             post)
-                test ! -f /home/$USER/blocked.bt && rfkill unblock bluetooth
-                rm /home/$USER/blocked.bt
+                cp -f "$BT_TMP_PATH"*bluetooth "$BT_STATES_PATH" 2> /dev/null
+                [ ! -f "$BT_BLOCK_PATH" ] && rfkill unblock bluetooth
+                rm "$BT_BLOCK_PATH" 2> /dev/null
+                rm "$BT_TMP_PATH"*bluetooth 2> /dev/null
                 ;;
         esac
         ;;

--- a/lib/systemd/system-sleep/pop-default-settings_bluetooth-suspend
+++ b/lib/systemd/system-sleep/pop-default-settings_bluetooth-suspend
@@ -20,8 +20,8 @@ case "$2" in
             post)
                 cp -f "$BT_TMP_PATH"*bluetooth "$BT_STATES_PATH" 2> /dev/null
                 [ ! -f "$BT_BLOCK_PATH" ] && rfkill unblock bluetooth
-                rm "$BT_BLOCK_PATH" 2> /dev/null
-                rm "$BT_TMP_PATH"*bluetooth 2> /dev/null
+                rm -f "$BT_BLOCK_PATH" 2> /dev/null
+                rm -f "$BT_TMP_PATH"*bluetooth 2> /dev/null
                 ;;
         esac
         ;;


### PR DESCRIPTION
This is a follow up to #144 that handles the situation where there are
multiple bluetooth entries in /var/lib/systemd/rfkill.  The current
version would lead to a shell error and would not save the state
properly.  This new version sorts the output of the bluetooth entries
and picks the highest one.

Moreover, storing a system-level runtime file in /home/$USER seems
inappropriate.  This new version stores the bluetooth state file in
/run, which is where such things normally are stored.

I've also introduced a few variables to make the code a bit cleaner.