### PR TITLE
feat: Use kyber IO scheduler for SSDs; bfq for rotational block devices

### DIFF
--- a/etc/modules-load.d/pop-modules.conf
+++ b/etc/modules-load.d/pop-modules.conf
@@ -1,0 +1,1 @@
+kyber-iosched

--- a/lib/udev/rules.d/60-block-pop.rules
+++ b/lib/udev/rules.d/60-block-pop.rules
@@ -1,0 +1,7 @@
+# BFQ is recommended for slow storage such as rotational block devices and SD cards.
+ACTION=="add|change", SUBSYSTEM=="block", ATTR{queue/rotational}=="1", ATTR{queue/scheduler}="bfq"
+ACTION=="add|change", SUBSYSTEM=="block", KERNEL=="mmcblk?", ATTR{queue/scheduler}="bfq"
+
+# Kyber is recommended for faster storage such as NVME and SATA SSDs.
+ACTION=="add|change", SUBSYSTEM=="block", ATTR{queue/rotational}=="0", KERNEL=="nvme?n?", ATTR{queue/scheduler}="kyber"
+ACTION=="add|change", SUBSYSTEM=="block", ATTR{queue/rotational}=="0", KERNEL=="sd?", ATTR{queue/scheduler}="kyber"


### PR DESCRIPTION
I've done some reading around and it seems that we're using an I/O scheduler that isn't ideal for NVME or SATA SSDs. We're defaulting to `none`, which can cause noticeable stutter and delay on the desktop when there are many processes performing I/O at the same time. Most Linux distributions are doing the same thing. It could be the cause of some of the reported issues with the system occasionally stuttering (there's reports that DRAM-less SSDs are more affected).

We may want to think about defaulting to Kyber for NVME and SATA SSDs, and BFQ for rotational drives. Kyber is a simple (< 1000 lines of code) and efficient multiqueue scheduler that's recommended in Red Hat documentation to be used by NVME/SATA SSDs. BFQ is a complex multiqueue scheduler that has a higher CPU cost but brings low latency benefits to slow rotational storage.

Tipped by some [Phoronix comments](https://www.phoronix.com/forums/forum/phoronix/latest-phoronix-articles/1334042-linux-5-19-looking-real-good-on-the-hp-dev-one-xanmod-liquorix-also-tested) talking about BFQ and None causing issues and Kyber being a good default for SSDs, I did some searching and found [this LWN article](https://lwn.net/Articles/720675/), [this Red Hat bugzilla issue](https://bugzilla.redhat.com/show_bug.cgi?id=1851783), [this Red Hat documentation](https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/8/html/monitoring_and_managing_system_status_and_performance/setting-the-disk-scheduler_monitoring-and-managing-system-status-and-performance), and [this research paper](https://www.barkhauseninstitut.org/fileadmin/user_upload/Publikationen/2019/201912_Miemietz_RTSS_K2.pdf).

From the Red Hat bugzilla issue report, there was a demand to enable mq-deadline for all SSDs because None and BFQ caused noticeable latency/stutter on the desktop for SSDs. However, MQ Deadline is focused more towards a server-oriented workflow with higher throughput at the cost of a higher latency, so I think Kyber will be better for the desktop use case. The K2 research paper also shows that Kyber has the lowest latency between BFQ, MQ Deadline, and None.

This should require testing to see how much of an impact this makes when doing a lot of I/O in the background. Perhaps playing an intensive 3D video game that streams textures and maps constantly, while also having multiple processes copying multiple files to different drives and across the network. It'd be good if we could find some people with NVME SSDs suffering from freezes that could try the change.

Note that it is working if you get an output like this:

```
$ cat /sys/block/nvme0n1/queue/scheduler
mq-deadline [kyber] bfq none
```
The change may impact max I/O throughput since that's the tradeoff made for improving desktop responsiveness.