### PR TITLE
fix(apt): Don't show phased updates in apt update output

### DIFF
--- a/etc/apt/apt.conf.d/76pop-default-settings
+++ b/etc/apt/apt.conf.d/76pop-default-settings
@@ -1,0 +1,1 @@
+APT::Get::Never-Include-Phased-Updates "true";


### PR DESCRIPTION
Ubuntu's phased updates currently do not show up in the Pop!_Shop, but they do show up in `apt update` output, despite being uninstallable with `apt upgrade`/`apt full-upgrade`. This config line makes them no longer show as available updates in `apt update` output, and prevents them from showing up as "held back" in `apt upgrade`/`apt full-upgrade` output (`apt policy` will still show if a package has a phased update in progress.)

The alternative to this would be `APT::Get::Always-Include-Phased-Updates "true";` and `Update-Manager::Always-Include-Phased-Updates "true";` to install the updates instead of hiding them, but that doesn't seem to affect the Pop!_Shop (and I can't find any separate config line for PackageKit), so it would result in inconsistent behavior between the Pop!_Shop and apt.