### PR TITLE
Set suspend settings to 30 minutes for new installs

### DIFF
--- a/usr/bin/pop-app-folders
+++ b/usr/bin/pop-app-folders
@@ -189,6 +189,19 @@ then
     dconf write /org/gnome/desktop/background/picture-uri-dark "${PICTURE_URI}"
 fi
 
+# Title 20 Compliance requires a display off setting of 5 minutes, and suspend of 30 minutes.
+# This is only for systems shipped by a company, so we need to check if the manufacturer is system76,
+# and if so set the suspend time to 30 minutes. This change is deliberatly done as part of
+# $CACHE_VERSION 6, and not as its own step so that existing Pop!_OS installs are not modified,
+# But new installs in the future are.
+if grep -q System76 /sys/devices/virtual/dmi/id/sys_vendor
+then
+    gsettings set org.gnome.settings-daemon.plugins.power sleep-inactive-ac-type suspend
+    gsettings set org.gnome.settings-daemon.plugins.power sleep-inactive-ac-timeout 1800
+    gsettings set org.gnome.settings-daemon.plugins.power sleep-inactive-battery-type suspend
+    gsettings set org.gnome.settings-daemon.plugins.power sleep-inactive-battery-timeout 1800
+fi
+
 echo "6" > "${CACHE_PATH}"
 
 fi


### PR DESCRIPTION
Because of Title 20 compliance for computer manufacturers new
Pop!_OS installs running system76 machines require 30 minute
auto-suspend.