### PR TITLE
Add new NTS servers

### DIFF
--- a/etc/chrony/sources.d/system76-nts.sources
+++ b/etc/chrony/sources.d/system76-nts.sources
@@ -1,3 +1,5 @@
 server virginia.time.system76.com iburst nts
 server ohio.time.system76.com iburst nts
 server oregon.time.system76.com iburst nts
+server paris.time.system76.com iburst nts
+server brazil.time.system76.com iburst nts


### PR DESCRIPTION
A couple of new time servers with NTS support have been created outside of the US. This updates the chrony configuration to use them.