### PR TITLE
update repoman mirror reset

### DIFF
--- a/debian/pop-default-settings.postinst
+++ b/debian/pop-default-settings.postinst
@@ -79,7 +79,7 @@ URIs: ${PROPRIETARY_REPO}
 Suites: ${RELEASE}
 Components: main"
 
-SYS_REPO="http://us.archive.ubuntu.com/ubuntu/"
+SYS_REPO="http://apt.pop-os.org/ubuntu"
 SYS_SOURCE="X-Repolib-Name: Pop_OS System Sources
 Enabled: yes
 Types: deb deb-src


### PR DESCRIPTION
This is to update the default mirror reset in Repoman from `http://us.archive.ubuntu.com/ubuntu/` to `http://apt.pop-os.org/ubuntu`.

Fixes: https://github.com/pop-os/repoman/issues/100