### PR TITLE
Allow fallback to insecure time servers

### DIFF
--- a/etc/chrony/conf.d/10-system76-nts.conf
+++ b/etc/chrony/conf.d/10-system76-nts.conf
@@ -1,2 +1,2 @@
-authselectmode prefer
+authselectmode ignore
 nocerttimecheck 1

--- a/etc/chrony/sources.d/system76-nts.sources
+++ b/etc/chrony/sources.d/system76-nts.sources
@@ -1,5 +1,5 @@
-server virginia.time.system76.com iburst nts
-server ohio.time.system76.com iburst nts
-server oregon.time.system76.com iburst nts
-server paris.time.system76.com iburst nts
-server brazil.time.system76.com iburst nts
+server virginia.time.system76.com iburst nts prefer trust
+server ohio.time.system76.com iburst nts prefer trust
+server oregon.time.system76.com iburst nts prefer trust
+server paris.time.system76.com iburst nts prefer trust
+server brazil.time.system76.com iburst nts prefer trust


### PR DESCRIPTION
### The problem

There have been a few reports of an inability to connect to our time servers using NTS. It appears that certain ISPs or company firewalls are incorrectly set up to block either the NTS Key Exchange or the larger NTS enhanced NTP packets. While this is wrong, it will prevent client machines on these networks from being able to synchronize their clocks - causing them to drift.

Both the `prefer` and `mixed` authselect modes in chrony disable unauthenticated sources in the presence of authenticated servers - even if they are not possible to connect to. This is for security reasons, as it would be easy to create a downgrade attack by blocking access to the secure servers, which is basically what the ISPs/firewalls are doing.

### The resolution

While it is not ideal, these updates allow for chrony to fall back to insecure time in the event that the network is blocking NTS. This significantly degrades security, but is necessary to prevent a regression of behavior. I am planning to add the commands for removing this fallback behavior to the hardening instructions at [https://system76.com/time](https://system76.com/time) . They are as follows:

```
echo "authselectmode prefer" | sudo tee /etc/chrony/conf.d/20-disable-insecure-fallback.conf
sudo systemctl restart chrony
```

### Note

When NTS is not being blocked our servers will still be preferred and trusted over unauthenticated time servers.