### PR TITLE
fix: Override dh_installdeb to overwrite auto-generated conffiles

### DIFF
--- a/debian/rules
+++ b/debian/rules
@@ -1,4 +1,8 @@
 #!/usr/bin/make -f
 
+override_dh_installdeb:
+	dh_installdeb
+	cp debian/pop-default-settings.conffiles debian/pop-default-settings/DEBIAN/conffiles
+
 %:
 	dh $@


### PR DESCRIPTION
Fixes https://github.com/pop-os/upgrade/issues/319.

The standard `dh_installdeb` takes our `pop-default-settings.conffiles` list and adds its auto-detected conffiles (anything under `/etc`) to that list. We need to override that by copying our list back over the generated one in order to prevent important files like `/etc/os-release` and `/etc/lsb-release` (which we package as `/etc/pop-os/os-release` and `/etc/pop-os/lsb-release`) from being declared as conffiles (which means they don't get updated by automated utilities like pop-upgrade).

For QA, note that if you're testing this on a system affected by the bug (running Jammy but showing a different release name in `/etc/os-release`), you'll need to correct the suite for the staging repository after adding it, because `apt-manage` will add it based on what's in `/etc/os-release`/`/etc/lsb-release`.