### PR TITLE
chore: remove Ubuntu Pro apt advertisements

### DIFF
--- a/debian/pop-default-settings.postinst
+++ b/debian/pop-default-settings.postinst
@@ -90,6 +90,9 @@ X-Repolib-Default-Mirror: ${SYS_REPO}"
 
 case "$1" in
     configure)
+        # Remove Ubuntu Pro advertisement
+        rm -f /etc/apt/apt.conf.d/20apt-esm-hook.conf
+
         for divert in "${diverts[@]}"
         do
             source="${divert%%=*}"


### PR DESCRIPTION
Resolves https://www.reddit.com/r/pop_os/comments/111vajn/ubuntu_pro_advertisements_in_pop_os/

This file is included by `ubuntu-advantage-tools`, which is a required dependency of `ubuntu-minimal`.