### PR TITLE
Set ideal MGLRU setting for desktop responsiveness

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -16,13 +16,19 @@ Depends: ${misc:Depends},
          gnupg,
          plymouth-theme-pop-basic,
          python3-repolib (>> 1.3.9),
-Recommends: pop-default-settings-zram
+Recommends: pop-default-settings-lru, pop-default-settings-zram
 Conflicts: pipewire-media-session
 Description: default settings for Pop OS
  This package contains the default settings used by Pop.
 
+Package: pop-default-settings-lru
+Architecture: all
+Depends: ${misc:Depends}, pop-default-settings
+Description: default settings for MGLRU on Pop
+ Configures ideal mglru parameters for desktop responsiveness
+
 Package: pop-default-settings-zram
 Architecture: all
 Depends: ${misc:Depends}, pop-default-settings, util-linux
-Description: default settings for ZRAM on Pop OS
- This package contains the default zram settings used by Pop.
+Description: default settings for ZRAM on Pop
+ Configures ideal zram parameters for desktop responsiveness

--- a/debian/pop-default-settings-lru.install
+++ b/debian/pop-default-settings-lru.install
@@ -1,0 +1,1 @@
+usr/bin/pop-lru-config

--- a/debian/pop-default-settings-lru.service
+++ b/debian/pop-default-settings-lru.service
@@ -1,0 +1,9 @@
+[Unit]
+Description=Configures MGLRU for desktop responsiveness
+
+[Service]
+Type=oneshot
+ExecStart=/usr/bin/pop-lru-config
+
+[Install]
+WantedBy=multi-user.target

--- a/usr/bin/pop-lru-config
+++ b/usr/bin/pop-lru-config
@@ -1,0 +1,5 @@
+#!/bin/sh
+# Make sure MGLRU is enabled.
+echo Y > /sys/kernel/mm/lru_gen/enabled
+# Preserve memory that was accessed within the last second.
+echo 1000 > /sys/kernel/mm/lru_gen/min_ttl_ms


### PR DESCRIPTION
This sets `/sys/kernel/mm/lru_gen/min_ttl_ms` to `1000` on startup, which ensures that any memory pages accessed within the last second will remain in memory, and avoid getting swapped or reclaimed. The default setting is `0`, which disables the feature.

Based on https://aur.archlinux.org/packages/mglru-desktop-settings

I've been tipped that this can noticeably improve YouTube or PC game responsiveness on a system that's out of memory, or close to it.