### PR TITLE
feat: Disable Firefox feature recommendation (CFR) pop-ups

### DIFF
--- a/usr/lib/firefox/browser/defaults/preferences/pop-default-settings.js
+++ b/usr/lib/firefox/browser/defaults/preferences/pop-default-settings.js
@@ -1,1 +1,2 @@
 pref("browser.newtabpage.activity-stream.feeds.section.topstories", false);
+pref("browser.newtabpage.activity-stream.asrouter.userprefs.cfr.features", false);


### PR DESCRIPTION
Firefox sends contextual feature recommendations (CFRs) on some updates. A bug currently causes the action buttons to be hidden: https://bugzilla.mozilla.org/show_bug.cgi?id=1946781

We're hiding the pop-ups for now because the buttons to dismiss them are broken. May be re-enabled after Firefox 140 is released.

Unblocks https://github.com/pop-os/packaging-firefox/pull/126 and should be released at the same time.