### PR TITLE
feat: automatically set wireless reg domain

### DIFF
--- a/debian/pop-default-settings.install
+++ b/debian/pop-default-settings.install
@@ -19,12 +19,16 @@ etc/xdg/autostart/pop-app-folders.desktop
 etc/xdg/autostart/pop-flatpak-repos.desktop
 lib/systemd/system-sleep/pop-default-settings_bluetooth-suspend
 lib/udev/rules.d/60-block-pop.rules
+lib/udev/rules.d/85-iw-regulatory.rules
 usr/bin/pop-app-folders
 usr/bin/pop-cosmic-favorites
 usr/bin/pop-flatpak-repos
 usr/lib/firefox/browser/defaults/preferences/pop-default-settings.js
 usr/lib/firefox/defaults/pref/pop-default-settings.js
+usr/lib/iw-set-regdomain
 usr/lib/systemd/journald.conf.d/pop.conf
+usr/lib/systemd/system/iw-set-regdomain.path
+usr/lib/systemd/system/iw-set-regdomain.service
 usr/share/applications/pop-mimeapps.list
 usr/share/gtksourceview-3.0/styles/pop-dark.xml
 usr/share/gtksourceview-3.0/styles/pop-light.xml

--- a/lib/udev/rules.d/85-iw-regulatory.rules
+++ b/lib/udev/rules.d/85-iw-regulatory.rules
@@ -1,0 +1,9 @@
+# SPDX-License-Identifier: ISC
+# SPDX-FileCopyrightText: 2025 Thomas Duckworth <tduck@filotimoproject.org>
+# SPDX-FileCopyrightText: 2009-2014 Red Hat, Inc.
+# SPDX-FileCopyrightText: 2025 Velocity Limitless, LLC.
+
+# Set wireless regulatory domain at device creation
+# For more information see https://gitlab.com/VelocityLimitless/Projects/iw-setregdomain
+
+SUBSYSTEM=="ieee80211", ACTION=="add", RUN+="/usr/lib/iw-set-regdomain"

--- a/usr/lib/iw-set-regdomain
+++ b/usr/lib/iw-set-regdomain
@@ -1,0 +1,83 @@
+#!/bin/sh
+
+# SPDX-License-Identifier: ISC
+# SPDX-FileCopyrightText: 2025 Thomas Duckworth <tduck@filotimoproject.org>
+# SPDX-FileCopyrightText: 2009-2014 Red Hat, Inc.
+# SPDX-FileCopyrightText: 2025 Velocity Limitless, LLC.
+
+# See https://gitlab.com/VelocityLimitless/Projects/iw-setregdomain
+
+# Copyright 2009-2014 Red Hat, Inc.  All rights reserved.
+#
+# Permission to use, copy, modify, and/or distribute this software for any
+# purpose with or without fee is hereby granted, provided that the above
+# copyright notice and this permission notice appear in all copies.
+#
+# THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+# WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+# MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+# ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+# WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+# ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+# OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+#
+
+REGDOMAIN=/etc/iw-regdomain
+LOCALTIME=/etc/localtime
+
+LOGGER="/usr/bin/logger -t iw-set-regdomain"
+
+getcountry() {
+	while read c a z r
+	do
+		if [ "$z" = "$ZONE" ]
+		then
+			echo $c
+			break
+		fi
+	done < /usr/share/zoneinfo/zone.tab
+}
+
+if [ -f $REGDOMAIN ]
+then
+	# This should set COUNTRY
+	. $REGDOMAIN
+	if [ -n "$COUNTRY" ]
+	then
+		/usr/bin/iw reg set $COUNTRY
+		exit
+	fi
+fi
+
+if [ -f "$LOCALTIME" ]
+then
+	ZONE=$(readlink -f $LOCALTIME)
+	ZONE=${ZONE#/usr/share/zoneinfo/}
+else
+	$LOGGER -s "Timezone information not found. Unable to set wireless regulatory domain."
+	exit 1
+fi
+
+if [ -z "$ZONE" -o "$ZONE" = "$LOCALTIME" ]
+then
+	$LOGGER -s "Could not determine timezone. Unable to set wireless regulatory domain."
+	exit 1
+fi
+
+COUNTRY=$(getcountry)
+
+if [ -z "$COUNTRY" ]
+then
+	case "$ZONE" in
+        UTC|UCT|Universal|Zulu|GMT|Etc/UTC|Etc/UCT|Etc/Universal|Etc/Zulu|Etc/GMT)
+            $LOGGER "Timezone is $ZONE, with no associated country. Not setting wireless regulatory domain."
+            exit 0
+            ;;
+    esac
+
+    $LOGGER -s "Could not determine country for $ZONE. Unable to set wireless regulatory domain."
+    exit 1
+fi
+
+$LOGGER "Setting regulatory domain to $COUNTRY based on timezone ($ZONE)."
+/usr/sbin/iw reg set $COUNTRY

--- a/usr/lib/systemd/system/iw-set-regdomain.path
+++ b/usr/lib/systemd/system/iw-set-regdomain.path
@@ -1,0 +1,12 @@
+# SPDX-License-Identifier: GPL-2.0-only OR GPL-3.0-only OR LicenseRef-KDE-Accepted-GPL
+# SPDX-FileCopyrightText: 2025 Thomas Duckworth <tduck@filotimoproject.org>
+
+[Unit]
+Description=Monitor Timezone Changes to Set Wireless Regulatory Domain
+
+[Path]
+PathChanged=/etc/localtime
+Unit=iw-set-regdomain.service
+
+[Install]
+WantedBy=multi-user.target

--- a/usr/lib/systemd/system/iw-set-regdomain.service
+++ b/usr/lib/systemd/system/iw-set-regdomain.service
@@ -1,0 +1,9 @@
+# SPDX-License-Identifier: GPL-2.0-only OR GPL-3.0-only OR LicenseRef-KDE-Accepted-GPL
+# SPDX-FileCopyrightText: 2025 Thomas Duckworth <tduck@filotimoproject.org>
+
+[Unit]
+Description=Set Wireless Regulatory Domain on Timezone Change
+
+[Service]
+Type=oneshot
+ExecStart=/usr/lib/iw-set-regdomain


### PR DESCRIPTION
Automatically calls `iw reg set ${country_code}` on startup and also when the timezone changes. This will improve wifi signal in some countries by enabling more channels, frequencies and/or higher power where they are available.

Based on https://invent.kde.org/kde-linux/kde-linux/-/merge_requests/367

Should be copied to the resolute branch