### PR TITLE
fix: enable udisks to mount NTFS partitions with ntfs3

### DIFF
--- a/debian/pop-default-settings.install
+++ b/debian/pop-default-settings.install
@@ -19,6 +19,7 @@ etc/xdg/autostart/pop-app-folders.desktop
 etc/xdg/autostart/pop-flatpak-repos.desktop
 lib/systemd/system-sleep/pop-default-settings_bluetooth-suspend
 lib/udev/rules.d/60-block-pop.rules
+lib/udev/rules.d/60-ntfs3.rules
 lib/udev/rules.d/85-iw-regulatory.rules
 usr/bin/pop-app-folders
 usr/bin/pop-cosmic-favorites

--- a/lib/udev/rules.d/60-ntfs3.rules
+++ b/lib/udev/rules.d/60-ntfs3.rules
@@ -1,0 +1,2 @@
+# Enables udisks to mount NTFS parititons with the ntfs3 module by default.
+SUBSYSTEM=="block", ENV{ID_FS_TYPE}=="ntfs", ENV{ID_FS_TYPE}="ntfs3" , ENV{UDISKS_FILESYSTEM_SHARED}="0"


### PR DESCRIPTION
It is required to define a udev rule to force udisks to use the new `ntfs` driver over `ntfs3` so that the user needn't install the less maintained `ntfs-3g` FUSE driver (which unsafely ignores the dirty bit flag in the file system). UDISKS_FILE_SYSTEMSHARED=0 is the default behavior for other file systems, which auto-mounts to `/media/{{volume-name}}` by default.