### PR TITLE
fix: increase open file limit for dbus-broker

### DIFF
--- a/debian/pop-default-settings.install
+++ b/debian/pop-default-settings.install
@@ -29,6 +29,7 @@ usr/lib/iw-set-regdomain
 usr/lib/systemd/journald.conf.d/pop.conf
 usr/lib/systemd/system/iw-set-regdomain.path
 usr/lib/systemd/system/iw-set-regdomain.service
+usr/lib/systemd/user/dbus-broker.service.d/10-cosmic-nofile.conf
 usr/share/applications/pop-mimeapps.list
 usr/share/gtksourceview-3.0/styles/pop-dark.xml
 usr/share/gtksourceview-3.0/styles/pop-light.xml

--- a/usr/lib/systemd/user/dbus-broker.service.d/10-cosmic-nofile.conf
+++ b/usr/lib/systemd/user/dbus-broker.service.d/10-cosmic-nofile.conf
@@ -1,0 +1,4 @@
+[Service]
+Restart=on-failure
+RestartSec=1
+LimitNOFILE=524288:1048576


### PR DESCRIPTION
I'm not sure if this is desired but here's the situation:

- If dbus-broker dies everything goes crazy (test it if you don't mind restarting your pc: pkill -f dbus-broker).
- Looks like from up-stream "restart" is set to false for dbus-broker, so if it crashes, it doesn't come back. It used to make sense since if it goes away, every client needs to re-establish their connection. Some of cosmic-apps don't. Some do, we can fix that. But as far as I know newer apps (even gtk ones) recover if they lose their dbus connection. So, restarting the dbus-broker shouldn't be a big deal. It may silently leave some apps in a bad state though.
- Currently the open file limit for dbus-broker is 1024!
- If we have a bunch of clients, it's easy to reach that number, if we reach that number dbus-broker crashes, becomes a zombie, systemd doesn't restart it. We die!

This PR adds a config file to increase the open file limit for dbus-broker, and also restart it on failure.

There are more fixes that need to happen across all COSMIC apps to avoid infinite loops if the dbus-broker crashes, and proper reconnection. I'll be opening those PRs later, but I'm curious if you guys are OK with this first step. If it makes sense? and if I understood the issue correctly.

Relevant mattermost chat: https://chat.pop-os.org/pop-os/pl/fdazztbf9igj88kfp7iqccbrco