### PR TITLE
fix: remove pop-im-ibus profile

### DIFF
--- a/debian/pop-default-settings.install
+++ b/debian/pop-default-settings.install
@@ -12,7 +12,6 @@ etc/pop-os/lsb-release
 etc/pop-os/os-release
 etc/pop-os/update-motd.d/10-help-text
 etc/pop-os/update-motd.d/50-motd-news
-etc/profile.d/pop-im-ibus.sh
 etc/sysctl.d/10-pop-default-settings.conf
 etc/update-manager/release-upgrades.d/pop-default-settings.cfg
 etc/xdg/autostart/pop-app-folders.desktop

--- a/etc/profile.d/pop-im-ibus.sh
+++ b/etc/profile.d/pop-im-ibus.sh
@@ -1,3 +1,0 @@
-export GTK_IM_MODULE="ibus"
-export QT_IM_MODULE="ibus"
-export XMODIFIERS="@im=ibus"


### PR DESCRIPTION
Not needed with COSMIC and will interfere with fcitx