### PR TITLE
fix: remove pop-im-ibus profile

### DIFF
--- a/etc/profile.d/pop-im-ibus.sh
+++ b/etc/profile.d/pop-im-ibus.sh
@@ -1,3 +1,0 @@
-export GTK_IM_MODULE="ibus"
-export QT_IM_MODULE="ibus"
-export XMODIFIERS="@im=ibus"


### PR DESCRIPTION
Not needed with COSMIC and will interfere with fcitx